### PR TITLE
Install fzf with apt

### DIFF
--- a/bin/dot-bootstrap
+++ b/bin/dot-bootstrap
@@ -34,8 +34,3 @@ fi
 if command -v terminal-notifier 1>/dev/null 2>&1; then
   terminal-notifier -title "dotfiles: Bootstrap complete" -message "Successfully set up dev environment."
 fi
-
-# Because fzf can be installed with apt from the next version of ubuntu it is installed manually
-# by cloning from git and running the below command. It isn't possible to do it with ansible,
-# since, when installing, you need set some parameters via yes/no questions
-echo "To install fzf run '~/.fzf/install'"

--- a/roles/tools/tasks/main.yml
+++ b/roles/tools/tasks/main.yml
@@ -1,9 +1,3 @@
-- name: Download fzf
-  git:
-    repo: https://github.com/junegunn/fzf.git
-    dest: ~/.fzf
-    depth: 1
-
 - name: Download diff-so-fancy
   git:
     repo: https://github.com/so-fancy/diff-so-fancy.git

--- a/roles/zsh/aliases.zsh
+++ b/roles/zsh/aliases.zsh
@@ -29,17 +29,13 @@ alias cat='bat'
 alias preview="fzf --preview 'bat --color \"always\" {}'"
 # add support for ctrl+o to open selected file in VS Code
 export FZF_DEFAULT_OPTS="--bind='ctrl-o:execute(code {})+abort'"
-
-# fzf good to know
-# CTRL-T - Paste the selected files and directories onto the command-line
-# CTRL-R - Paste the selected command from history onto the command-line
-# ALT-C - cd into the selected directory 
+# Using highlight (http://www.andre-simon.de/doku/highlight/en/highlight.html)
+export FZF_CTRL_T_OPTS="--preview '(highlight -O ansi -l {} 2> /dev/null || cat {} || tree -C {}) 2> /dev/null | head -200'"
 
 alias help='tldr'
 
-# fd good to know
-# fd cli # all filenames containing "cli"
-# fd -e md # all with .md extension
-# fd cli -x wc -w # find "cli" and run `wc -w` on each file
 
 alias top="sudo htop"
+
+alias shortcuts="bat /home/dinko/.dotfiles/roles/zsh/keyboard_shortcuts.zsh"
+alias gitf="git aliases | fzf"

--- a/roles/zsh/files/zshrc
+++ b/roles/zsh/files/zshrc
@@ -148,4 +148,12 @@ source $HOME/.dotfiles/roles/zsh/path.zsh
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 
+
+# Enable fzf keybindings for Zsh
+source /usr/share/doc/fzf/examples/key-bindings.zsh
+
+# Enable fuzzy auto-completion for Zsh
+source /usr/share/doc/fzf/examples/completion.zsh
+
+
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh

--- a/roles/zsh/keyboard_shortcuts.zsh
+++ b/roles/zsh/keyboard_shortcuts.zsh
@@ -1,0 +1,18 @@
+# List of keyboard shortcuts for CLI tools
+
+#######
+# FZF #
+#######
+
+<CTRL+T> # list files+folders in current directory (e.g., git commit <CTRL+T>, select a few files using <TAB>, finally <Return>)
+<CTRL+R> # search history of shell commands
+<ALT+C>  # fuzzy change directory
+
+######
+# FD #
+######
+
+fd cli   # find all files containing "cli"
+fd -e md  # find files all with .md extension
+fd cli -x wc -w  # find "cli" and run `wc -w` on each file
+


### PR DESCRIPTION
Closes #1 

fzf is now installed with apt. CTRL+R or T or ALT+C are added as default behaviour.